### PR TITLE
Bugfix/config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 build/
 yarn.lock
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -5,35 +5,31 @@ var objectAssign = require('object-assign');
 var apidoc = require('apidoc');
 var pname = require('./package.json').name;
 
-module.exports = function(opt,done) {
+module.exports = function(opt, done) {
 
-	var _opt = objectAssign({
-		dest: opt.dest || opt.o || 'doc/',
-		config: opt.config || opt.c || opt.src,
-		src: opt.src || opt.i
-		},
-		opt);
+    var _opt = objectAssign({
+        dest: opt.dest || opt.o || 'doc/',
+        src: opt.src || opt.i,
+        apidocPath: opt.config || __dirname
+    }, opt);
 
-	if(_opt.template || _opt.t){
-		_opt.template =  _opt.template || _opt.t;
-	}
+    if(_opt.template || _opt.t) {
+        _opt.template = _opt.template || _opt.t;
+    }
 
+    if(_opt.src) {
+        var chunk = apidoc.createDoc(_opt);
 
-	if(_opt.src){
-
-		var chunk = apidoc.createDoc(_opt);
-
-		if(typeof chunk === 'object') {
-	    	log(pname+' '+ colors.green('Apidoc created...   [  '+ colors.cyan(JSON.parse(chunk.project).name) +'  ] '));
-			done();
-		} else if(chunk === true){
-			log(pname+' '+colors.green('Apidoc created... '));
-			done();
-		}else{
-			done(new PluginError(pname, 'Execution terminated (set \" debug: true \" in gulpfile.js for details. '))
-		}
-
-	}else{
-		done(new PluginError(pname, 'Folder specified'));
-	}
+        if(typeof chunk === 'object') {
+            log(pname + ' ' + colors.green('Apidoc created...   [  ' + colors.cyan(JSON.parse(chunk.project).name) + '  ] '));
+            done();
+        } else if(chunk === true) {
+            log(pname + ' ' + colors.green('Apidoc created... '));
+            done();
+        } else {
+            done(new PluginError(pname, 'Execution terminated (set \" debug: true \" in gulpfile.js for details. '))
+        }
+    } else {
+        done(new PluginError(pname, 'Folder specified'));
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,11 @@
-***this package is no longer supported, use the [webpack plugin](https://github.com/c0b41/webpack-apidoc) instead*** 
+# [gulp](https://github.com/gulpjs/gulp)-apidoc
 
-# [gulp](https://github.com/gulpjs/gulp)-apidoc 
-
-
-![npm-version](https://img.shields.io/npm/v/gulp-apidoc.svg)
-![download-count](https://img.shields.io/npm/dm/gulp-apidoc.svg)
-![dev-deps](https://david-dm.org/c0b41/gulp-apidoc.svg)
-
-
-Generates a RESTful web API Documentationusing the [apidoc](https://github.com/apidoc/apidoc) library.
+Generates a RESTful web API Documentation using the [apidoc](https://github.com/apidoc/apidoc) library.
 
 ## How It Works
+
 `/path/api/stuff.js`:
+
 ```js
 /**
  * @api {get} /user/:id Request User information
@@ -25,59 +19,57 @@ Generates a RESTful web API Documentationusing the [apidoc](https://github.com/a
  */
 ```
 
-
 ## Install
 
-Install with [npm](https://npmjs.org/package/gulp-apidoc)
+Install with GitHub:
 
-```
-npm install --save-dev gulp-apidoc
+```cli
+npm install --save-dev devallama/gulp-apidoc
 ```
 
+Soon to be on NPM (hopefully).
 
 ## Usage
 
-```js
-var gulp = require('gulp'),
+```shell
+const gulp = require('gulp'),
     apidoc = require('gulp-apidoc');
 
-gulp.task('apidoc', function(done){
-          apidoc({
-            src: "example/",
-            dest: "build/"
-          },done);
+gulp.task('apidoc', function(done) {
+    apidoc({
+        src: "example/",
+        dest: "build/"
+    }, done);
 });
 ```
 
 With options:
 
 ```js
-var gulp = require('gulp'),
+const gulp = require('gulp'),
     apidoc = require('gulp-apidoc');
 
-gulp.task('apidoc',function(done){
-              apidoc({
-	              src: "example/",
-                  dest: "build/",
-                  template: "template/",
-                  debug: true,
-                  includeFilters: [ ".*\\.js$" ]
-              },done);
+gulp.task('apidoc', function(done) {
+    apidoc({
+        src: "example/",
+        dest: "build/",
+        template: "template/",
+        debug: true,
+        config: "configurations/",
+        includeFilters: [ ".*\\.js$" ]
+    }, done);
 });
 ```
 
 Other options [checkout](https://github.com/apidoc/apidoc/blob/master/lib/index.js#L14-L21).
 
-
 ## Options
-
 
 #### options.src
 
 The folder to scan for apidoc documentation.
 
 Type: `String`
-
 
 #### options.dest
 
@@ -121,3 +113,6 @@ Default: `false`
 
 Type: `Array`
 Default: `[]`
+
+---
+Forked from [c0b41/gulp-apidoc](https://github.com/c0b41/gulp-apidoc)


### PR DESCRIPTION
Fixes module not finding the apidoc.json config when in the root project directory, by setting apidocPath option for apidoc.

The apidocPath is set to the base directory folder (__dirname) by default or the option.config folder if specified.